### PR TITLE
Simplify and enable redact to walk interfaces and arrays

### DIFF
--- a/redact_test.go
+++ b/redact_test.go
@@ -214,7 +214,7 @@ func TestInterface(t *testing.T) {
 	i := interface{}(&TestStruct{})
 	err := redact.Redact(&i)
 	assert.NoError(t, err)
-	assert.Equal(t, i, &TestStruct{}) // this is broken
+	assert.Equal(t, i, &TestStruct{Secret: redact.RedactStrConst, SecretStringType: redact.RedactStrConst})
 }
 
 func TestNestedStructs(t *testing.T) {
@@ -250,7 +250,6 @@ func TestArray(t *testing.T) {
 
 	assert.Equal(t, "", tStruct.NotSecretStrings[0], "should contain non secret value")
 	assert.Equal(t, "", tStruct.NotSecretStrings[1], "should contain non secret value")
-	// these are broken
-	// assert.Equal(t, redact.RedactStrConst, tStruct.SecretStrings[0], "should redact secret value")
-	// assert.Equal(t, redact.RedactStrConst, tStruct.SecretStrings[1], "should redact secret value")
+	assert.Equal(t, redact.RedactStrConst, tStruct.SecretStrings[0], "should redact secret value")
+	assert.Equal(t, redact.RedactStrConst, tStruct.SecretStrings[1], "should redact secret value")
 }


### PR DESCRIPTION
fixes #4 

The first commit of this PR adds unit test coverage to redact.Redact, including tests that highlight the broken interface (and array) behavior documented in #4.

The second commit is a rewrite which is better structured and clearly covers all of the necessary Go kinds in its recursion.  I believe that it is identical in its behavior (apart from the bug fixes) to the code that preceded it.

@samkreter please could you take a look, and if you're happy to merge, tag a new library version?  Thank-you!