### PR TITLE
implement redact.AsCopy()

### DIFF
--- a/ascopy.go
+++ b/ascopy.go
@@ -1,0 +1,66 @@
+package redact
+
+import "reflect"
+
+// AsCopy redacts all strings without the nonsecret tag, returning a copy of the argument.  Important: the argument is not modified, but
+// unexported fields are not deep copied.  There could be pointer aliasing within unexported fields.  It cannot be guaranteed that a
+// subsequent mutation to the argument will not mutate the result, or vice-versa.
+func AsCopy[T any](t T) T {
+	return asCopy(reflect.ValueOf(t), nonSecret).Interface().(T)
+}
+
+func asCopy(in reflect.Value, tag string) reflect.Value {
+	out := in
+
+	switch in.Kind() {
+	case reflect.Array:
+		out = reflect.New(in.Type()).Elem()
+		for i := 0; i < in.Len(); i++ {
+			out.Index(i).Set(asCopy(in.Index(i), tag))
+		}
+
+	case reflect.Interface:
+		if !in.IsNil() {
+			out = reflect.New(in.Type()).Elem()
+			out.Set(asCopy(in.Elem(), tag))
+		}
+
+	case reflect.Map:
+		if !in.IsNil() {
+			out = reflect.MakeMapWithSize(in.Type(), in.Len())
+			iter := in.MapRange()
+			for iter.Next() {
+				out.SetMapIndex(iter.Key(), asCopy(iter.Value(), tag))
+			}
+		}
+
+	case reflect.Pointer:
+		if !in.IsNil() {
+			out = asCopy(in.Elem(), tag).Addr()
+		}
+
+	case reflect.Slice:
+		if !in.IsNil() {
+			out = reflect.MakeSlice(in.Type(), in.Len(), in.Len())
+			for i := 0; i < in.Len(); i++ {
+				out.Index(i).Set(asCopy(in.Index(i), tag))
+			}
+		}
+
+	case reflect.String:
+		out = reflect.New(in.Type()).Elem()
+		out.SetString(transformString(in.String(), tag))
+
+	case reflect.Struct:
+		out = reflect.New(in.Type()).Elem()
+		out.Set(in)
+		for i := 0; i < in.NumField(); i++ {
+			if in.Field(i).CanSet() {
+				tag, _ := in.Type().Field(i).Tag.Lookup(tagName)
+				out.Field(i).Set(asCopy(in.Field(i), tag))
+			}
+		}
+	}
+
+	return out
+}

--- a/no_exported_alias_test.go
+++ b/no_exported_alias_test.go
@@ -1,0 +1,100 @@
+package redact
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// exportedAddresses recurses a value v, returning a map of non-nil addresses of all of the exported sub-values found and the path to those
+// values.
+func exportedAddresses(path string, v any) map[uintptr][]string {
+	m := map[uintptr][]string{}
+	recurseExportedAddresses(m, path, reflect.ValueOf(v).Elem())
+	return m
+}
+
+func recurseExportedAddresses(m map[uintptr][]string, path string, v reflect.Value) {
+	switch v.Kind() {
+	case reflect.Array:
+		if v.Len() == 0 {
+			saveAddress(m, path, v)
+		} else {
+			for i := 0; i < v.Len(); i++ {
+				recurseExportedAddresses(m, path+fmt.Sprintf("[%d]", i), v.Index(i))
+			}
+		}
+
+	case reflect.Chan:
+		saveAddress(m, path, v)
+		savePointerAddress(m, path+"[chan]", v)
+
+	case reflect.Interface, reflect.Pointer, reflect.UnsafePointer:
+		saveAddress(m, path, v)
+
+		if !v.IsNil() {
+			recurseExportedAddresses(m, path, v.Elem())
+		}
+
+	case reflect.Map:
+		saveAddress(m, path, v)
+		savePointerAddress(m, path+"[map]", v)
+
+		iter := v.MapRange()
+		for iter.Next() {
+			recurseExportedAddresses(m, path+fmt.Sprintf("[%v;key]", iter.Key()), iter.Key())
+			recurseExportedAddresses(m, path+fmt.Sprintf("[%v]", iter.Key()), iter.Value())
+		}
+
+	case reflect.Slice:
+		saveAddress(m, path, v)
+
+		if v.Len() == 0 && v.Cap() != 0 {
+			savePointerAddress(m, path+"[slice]", v)
+		} else {
+			for i := 0; i < v.Len(); i++ {
+				recurseExportedAddresses(m, path+"[0]", v.Index(i))
+			}
+		}
+
+	case reflect.Struct:
+		if v.NumField() == 0 {
+			saveAddress(m, path, v)
+		} else {
+			for i := 0; i < v.NumField(); i++ {
+				if v.Type().Field(i).IsExported() {
+					recurseExportedAddresses(m, path+"."+v.Type().Field(i).Name, v.Field(i))
+				}
+			}
+		}
+
+	default:
+		saveAddress(m, path, v)
+	}
+}
+
+func saveAddress(m map[uintptr][]string, path string, v reflect.Value) {
+	if v.CanAddr() && !v.Addr().IsNil() {
+		m[v.Addr().Pointer()] = append(m[v.Addr().Pointer()], path)
+	}
+}
+
+func savePointerAddress(m map[uintptr][]string, path string, v reflect.Value) {
+	if !v.IsNil() {
+		m[v.Pointer()] = append(m[v.Pointer()], path)
+	}
+}
+
+// ValidateNoExportedAliases validates that no exported sub-value of `a` shares the same memory address of a sub-value of `b`.  The
+// intention is to guarantee that a mutation of `b` cannot inadvertently cause a mutation of `a`.
+func ValidateNoExportedAliases(a, b any) (errs []error) {
+	aptrs, bptrs := exportedAddresses("a", a), exportedAddresses("b", b)
+
+	for aptr, apaths := range aptrs {
+		if bpaths := bptrs[aptr]; bpaths != nil {
+			errs = append(errs, fmt.Errorf("%s and %s are aliases", strings.Join(apaths, ", "), strings.Join(bpaths, ", ")))
+		}
+	}
+
+	return errs
+}

--- a/redact.go
+++ b/redact.go
@@ -21,13 +21,13 @@ func AddRedactor(key string, r redactor) {
 }
 
 // Redact redacts all strings without the nonsecret tag
-func Redact(iface interface{}) error {
-	ifv := reflect.ValueOf(iface)
-	if ifv.Kind() != reflect.Ptr {
+func Redact(val any) error {
+	v := reflect.ValueOf(val)
+	if v.Kind() != reflect.Ptr {
 		return errors.New("Not a pointer")
 	}
 
-	redact(reflect.Indirect(ifv), nonSecret)
+	redact(v.Elem(), nonSecret)
 	return nil
 }
 

--- a/redact.go
+++ b/redact.go
@@ -45,11 +45,12 @@ func redact(v reflect.Value, tag string) {
 
 	case reflect.Map:
 		if !v.IsNil() {
-			for _, key := range v.MapKeys() {
+			iter := v.MapRange()
+			for iter.Next() {
 				val := reflect.New(v.Type().Elem()).Elem()
-				val.Set(v.MapIndex(key))
+				val.Set(iter.Value())
 				redact(val, tag)
-				v.SetMapIndex(key, val)
+				v.SetMapIndex(iter.Key(), val)
 			}
 		}
 

--- a/redact_test.go
+++ b/redact_test.go
@@ -24,6 +24,7 @@ type TestStruct struct {
 	SecretStringType StringType
 	SecretPtr        *string
 	NonSecret        string `redact:"nonsecret"`
+	Interface        interface{}
 	unexported       string
 	unexportedMap    map[string]string
 }
@@ -52,206 +53,367 @@ type TestNestedStruct struct {
 
 func TestStringTestStruct(t *testing.T) {
 	t.Run("Basic Secret Redaction", func(t *testing.T) {
-		tStruct := &TestStruct{
-			NonSecret:        nonSecretVal,
-			Secret:           secretVal,
-			SecretStringType: secretVal,
-			SecretPtr:        &secretPtrVal,
-			unexported:       nonSecretVal,
-			unexportedMap:    map[string]string{"": ""},
+		newTestStruct := func() *TestStruct {
+			return &TestStruct{
+				NonSecret:        nonSecretVal,
+				Secret:           secretVal,
+				SecretStringType: secretVal,
+				SecretPtr:        &secretPtrVal,
+				unexported:       nonSecretVal,
+				unexportedMap:    map[string]string{"": ""},
+			}
 		}
 
+		validate := func(tStruct *TestStruct) {
+			assert.Equal(t, nonSecretVal, tStruct.NonSecret, "should contain non secret value")
+			assert.Equal(t, redact.RedactStrConst, tStruct.Secret, "should redact secret value")
+			assert.Equal(t, StringType(redact.RedactStrConst), tStruct.SecretStringType, "should redact secret value")
+			assert.Equal(t, redact.RedactStrConst, *tStruct.SecretPtr, "should redact secret value")
+			assert.Equal(t, nonSecretVal, tStruct.unexported, "should contain non secret value")
+		}
+
+		tStruct := newTestStruct()
 		err := redact.Redact(tStruct)
 		assert.NoError(t, err, "should not fail to redact struct")
+		validate(tStruct)
 
-		assert.Equal(t, nonSecretVal, tStruct.NonSecret, "should contain non secret value")
-		assert.Equal(t, redact.RedactStrConst, tStruct.Secret, "should redact secret value")
-		assert.Equal(t, StringType(redact.RedactStrConst), tStruct.SecretStringType, "should redact secret value")
-		assert.Equal(t, redact.RedactStrConst, *tStruct.SecretPtr, "should redact secret value")
-		assert.Equal(t, nonSecretVal, tStruct.unexported, "should contain non secret value")
+		tStruct = newTestStruct()
+		tStructCopy := redact.AsCopy(tStruct)
+		assert.Equal(t, newTestStruct(), tStruct)
+		validate(tStructCopy)
+		redact.ValidateNoExportedAliases(tStruct, tStructCopy)
 	})
 
 	t.Run("Should still redact empty strings", func(t *testing.T) {
-		emptyStrVal := ""
+		newTestStruct := func() *TestStruct {
+			emptyStrVal := ""
 
-		tStruct := &TestStruct{
-			NonSecret: nonSecretVal,
-			Secret:    "",
-			SecretPtr: &emptyStrVal,
+			return &TestStruct{
+				NonSecret: nonSecretVal,
+				Secret:    "",
+				SecretPtr: &emptyStrVal,
+			}
 		}
 
+		validate := func(tStruct *TestStruct) {
+			assert.Equal(t, nonSecretVal, tStruct.NonSecret, "should contain non secret value")
+			assert.Equal(t, redact.RedactStrConst, tStruct.Secret, "should redact secret value")
+			assert.Equal(t, redact.RedactStrConst, *tStruct.SecretPtr, "should redact secret value")
+		}
+
+		tStruct := newTestStruct()
 		err := redact.Redact(tStruct)
 		assert.NoError(t, err, "should not fail to redact struct")
+		validate(tStruct)
 
-		assert.Equal(t, nonSecretVal, tStruct.NonSecret, "should contain non secret value")
-		assert.Equal(t, redact.RedactStrConst, tStruct.Secret, "should redact secret value")
-		assert.Equal(t, redact.RedactStrConst, *tStruct.SecretPtr, "should redact secret value")
+		tStruct = newTestStruct()
+		tStructCopy := redact.AsCopy(tStruct)
+		assert.Equal(t, newTestStruct(), tStruct)
+		validate(tStructCopy)
+		redact.ValidateNoExportedAliases(tStruct, tStructCopy)
 	})
-
 }
 
 func TestStringTestStructList(t *testing.T) {
 	t.Run("Basic Secret Redaction", func(t *testing.T) {
-		tStruct := &TestStruct{
-			NonSecret: nonSecretVal,
-			Secret:    secretVal,
-			SecretPtr: &secretPtrVal,
+		newTestStructList := func() *TestStructList {
+			tStruct := &TestStruct{
+				NonSecret: nonSecretVal,
+				Secret:    secretVal,
+				SecretPtr: &secretPtrVal,
+			}
+
+			return &TestStructList{
+				Data:               []*TestStruct{tStruct},
+				StringSliceData:    []string{secretVal},
+				IntSliceData:       []int{0},
+				StringPtrSliceData: []*string{&secretPtrVal, nil},
+			}
 		}
 
-		list := &TestStructList{
-			Data:               []*TestStruct{tStruct},
-			StringSliceData:    []string{secretVal},
-			IntSliceData:       []int{0},
-			StringPtrSliceData: []*string{&secretPtrVal, nil},
+		validate := func(list *TestStructList) {
+			assert.Equal(t, nonSecretVal, list.Data[0].NonSecret, "should contain non secret value")
+			assert.Equal(t, redact.RedactStrConst, list.Data[0].Secret, "should redact secret value")
+			assert.Equal(t, redact.RedactStrConst, *list.Data[0].SecretPtr, "should redact secret value")
+			assert.Equal(t, redact.RedactStrConst, list.StringSliceData[0], "should redact secret value")
+			assert.Equal(t, redact.RedactStrConst, *list.StringPtrSliceData[0], "should redact secret value")
 		}
 
+		list := newTestStructList()
 		err := redact.Redact(list)
 		assert.NoError(t, err, "should not fail to redact struct")
+		validate(list)
 
-		assert.Equal(t, nonSecretVal, list.Data[0].NonSecret, "should contain non secret value")
-		assert.Equal(t, redact.RedactStrConst, list.Data[0].Secret, "should redact secret value")
-		assert.Equal(t, redact.RedactStrConst, *list.Data[0].SecretPtr, "should redact secret value")
-		assert.Equal(t, redact.RedactStrConst, list.StringSliceData[0], "should redact secret value")
-		assert.Equal(t, redact.RedactStrConst, *list.StringPtrSliceData[0], "should redact secret value")
+		list = newTestStructList()
+		listCopy := redact.AsCopy(list)
+		assert.Equal(t, newTestStructList(), list)
+		validate(listCopy)
+		redact.ValidateNoExportedAliases(list, listCopy)
 	})
 
 	t.Run("Should still redact empty strings", func(t *testing.T) {
-		emptyStrVal := ""
+		newTestStructList := func() *TestStructList {
+			emptyStrVal := ""
 
-		tStruct := &TestStruct{
-			NonSecret: nonSecretVal,
-			Secret:    "",
-			SecretPtr: &emptyStrVal,
+			tStruct := &TestStruct{
+				NonSecret: nonSecretVal,
+				Secret:    "",
+				SecretPtr: &emptyStrVal,
+			}
+
+			return &TestStructList{
+				Data:               []*TestStruct{tStruct},
+				StringSliceData:    []string{""},
+				IntSliceData:       []int{0},
+				StringPtrSliceData: []*string{&[]string{""}[0], nil},
+			}
 		}
 
-		list := &TestStructList{
-			Data:               []*TestStruct{tStruct},
-			StringSliceData:    []string{""},
-			IntSliceData:       []int{0},
-			StringPtrSliceData: []*string{&[]string{""}[0], nil},
+		validate := func(list *TestStructList) {
+			assert.Equal(t, nonSecretVal, list.Data[0].NonSecret, "should contain non secret value")
+			assert.Equal(t, redact.RedactStrConst, list.Data[0].Secret, "should redact secret value")
+			assert.Equal(t, redact.RedactStrConst, *list.Data[0].SecretPtr, "should redact secret value")
+			assert.Equal(t, redact.RedactStrConst, list.StringSliceData[0], "should redact secret value")
+			assert.Equal(t, redact.RedactStrConst, *list.StringPtrSliceData[0], "should redact secret value")
 		}
 
+		list := newTestStructList()
 		err := redact.Redact(list)
 		assert.NoError(t, err, "should not fail to redact struct")
+		validate(list)
 
-		assert.Equal(t, nonSecretVal, list.Data[0].NonSecret, "should contain non secret value")
-		assert.Equal(t, redact.RedactStrConst, list.Data[0].Secret, "should redact secret value")
-		assert.Equal(t, redact.RedactStrConst, *list.Data[0].SecretPtr, "should redact secret value")
-		assert.Equal(t, redact.RedactStrConst, list.StringSliceData[0], "should redact secret value")
-		assert.Equal(t, redact.RedactStrConst, *list.StringPtrSliceData[0], "should redact secret value")
+		list = newTestStructList()
+		listCopy := redact.AsCopy(list)
+		assert.Equal(t, newTestStructList(), list)
+		validate(listCopy)
+		redact.ValidateNoExportedAliases(list, listCopy)
 	})
-
 }
 
 func TestStringTestMapAndEmbedded(t *testing.T) {
 	t.Run("Should Redact Map And Slice Structs", func(t *testing.T) {
-		tMaps := &TestMaps{
-			Secrets: map[string]string{
-				"secret-key-old": secretVal,
-				"secret-key-new": secretVal,
-			},
-			SecretPtrs: map[string]*string{
-				"ptr-secret-key": &secretPtrVal,
-			},
-			TestStructSecrets: map[string]*TestStruct{
-				"ptr-test-struct-key": {
-					NonSecret: nonSecretVal,
-					Secret:    secretVal,
-					SecretPtr: &secretPtrVal,
+		newTestMaps := func() *TestMaps {
+			return &TestMaps{
+				Secrets: map[string]string{
+					"secret-key-old": secretVal,
+					"secret-key-new": secretVal,
 				},
-			},
+				SecretPtrs: map[string]*string{
+					"ptr-secret-key": &secretPtrVal,
+				},
+				TestStructSecrets: map[string]*TestStruct{
+					"ptr-test-struct-key": {
+						NonSecret: nonSecretVal,
+						Secret:    secretVal,
+						SecretPtr: &secretPtrVal,
+					},
+				},
+			}
 		}
 
+		validate := func(tMaps *TestMaps) {
+			assert.Equal(t, redact.RedactStrConst, tMaps.Secrets["secret-key-old"], "should redact secret value")
+			assert.Equal(t, redact.RedactStrConst, tMaps.Secrets["secret-key-new"], "should redact secret value")
+			assert.Equal(t, redact.RedactStrConst, *tMaps.SecretPtrs["ptr-secret-key"], "should redact secret value")
+			assert.Equal(t, redact.RedactStrConst, tMaps.TestStructSecrets["ptr-test-struct-key"].Secret, "should redact secret value")
+			assert.Equal(t, redact.RedactStrConst, *tMaps.TestStructSecrets["ptr-test-struct-key"].SecretPtr, "should redact secret value")
+			assert.Equal(t, nonSecretVal, tMaps.TestStructSecrets["ptr-test-struct-key"].NonSecret, "should redact secret value")
+		}
+
+		tMaps := newTestMaps()
 		err := redact.Redact(tMaps)
 		assert.NoError(t, err, "should not fail to redact struct")
+		validate(tMaps)
 
-		assert.Equal(t, redact.RedactStrConst, tMaps.Secrets["secret-key-old"], "should redact secret value")
-		assert.Equal(t, redact.RedactStrConst, tMaps.Secrets["secret-key-new"], "should redact secret value")
-		assert.Equal(t, redact.RedactStrConst, *tMaps.SecretPtrs["ptr-secret-key"], "should redact secret value")
-		assert.Equal(t, redact.RedactStrConst, tMaps.TestStructSecrets["ptr-test-struct-key"].Secret, "should redact secret value")
-		assert.Equal(t, redact.RedactStrConst, *tMaps.TestStructSecrets["ptr-test-struct-key"].SecretPtr, "should redact secret value")
-		assert.Equal(t, nonSecretVal, tMaps.TestStructSecrets["ptr-test-struct-key"].NonSecret, "should redact secret value")
+		tMaps = newTestMaps()
+		tMapsCopy := redact.AsCopy(tMaps)
+		assert.Equal(t, newTestMaps(), tMaps)
+		validate(tMapsCopy)
+		redact.ValidateNoExportedAliases(tMaps, tMapsCopy)
 	})
 
 	t.Run("Should Redact Map And Slice Structs", func(t *testing.T) {
-		tMaps := &TestMaps{
-			Secrets: map[string]string{
-				"secret-key-old": secretVal,
-				"secret-key-new": secretVal,
-			},
-			SecretPtrs: map[string]*string{
-				"ptr-secret-key": &secretPtrVal,
-			},
-			TestStructSecrets: map[string]*TestStruct{
-				"ptr-test-struct-key": {
-					NonSecret: nonSecretVal,
-					Secret:    secretVal,
-					SecretPtr: &secretPtrVal,
+		newTestMapList := func() *TestMapList {
+			tMaps := &TestMaps{
+				Secrets: map[string]string{
+					"secret-key-old": secretVal,
+					"secret-key-new": secretVal,
 				},
-			},
+				SecretPtrs: map[string]*string{
+					"ptr-secret-key": &secretPtrVal,
+				},
+				TestStructSecrets: map[string]*TestStruct{
+					"ptr-test-struct-key": {
+						NonSecret: nonSecretVal,
+						Secret:    secretVal,
+						SecretPtr: &secretPtrVal,
+					},
+				},
+			}
+
+			return &TestMapList{
+				Data: []*TestMaps{tMaps},
+			}
 		}
 
-		testMapList := &TestMapList{
-			Data: []*TestMaps{tMaps},
+		validate := func(testMapList *TestMapList) {
+			assert.Equal(t, redact.RedactStrConst, testMapList.Data[0].Secrets["secret-key-old"], "should redact secret value")
+			assert.Equal(t, redact.RedactStrConst, testMapList.Data[0].Secrets["secret-key-new"], "should redact secret value")
+			assert.Equal(t, redact.RedactStrConst, *testMapList.Data[0].SecretPtrs["ptr-secret-key"], "should redact secret value")
+			assert.Equal(t, redact.RedactStrConst, testMapList.Data[0].TestStructSecrets["ptr-test-struct-key"].Secret, "should redact secret value")
+			assert.Equal(t, redact.RedactStrConst, *testMapList.Data[0].TestStructSecrets["ptr-test-struct-key"].SecretPtr, "should redact secret value")
+			assert.Equal(t, nonSecretVal, testMapList.Data[0].TestStructSecrets["ptr-test-struct-key"].NonSecret, "should redact secret value")
 		}
 
+		testMapList := newTestMapList()
 		err := redact.Redact(testMapList)
 		assert.NoError(t, err, "should not fail to redact struct")
+		validate(testMapList)
 
-		assert.Equal(t, redact.RedactStrConst, testMapList.Data[0].Secrets["secret-key-old"], "should redact secret value")
-		assert.Equal(t, redact.RedactStrConst, testMapList.Data[0].Secrets["secret-key-new"], "should redact secret value")
-		assert.Equal(t, redact.RedactStrConst, *testMapList.Data[0].SecretPtrs["ptr-secret-key"], "should redact secret value")
-		assert.Equal(t, redact.RedactStrConst, testMapList.Data[0].TestStructSecrets["ptr-test-struct-key"].Secret, "should redact secret value")
-		assert.Equal(t, redact.RedactStrConst, *testMapList.Data[0].TestStructSecrets["ptr-test-struct-key"].SecretPtr, "should redact secret value")
-		assert.Equal(t, nonSecretVal, testMapList.Data[0].TestStructSecrets["ptr-test-struct-key"].NonSecret, "should redact secret value")
+		testMapList = newTestMapList()
+		testMapListCopy := redact.AsCopy(testMapList)
+		assert.Equal(t, newTestMapList(), testMapList)
+		validate(testMapListCopy)
+		redact.ValidateNoExportedAliases(testMapList, testMapListCopy)
 	})
 }
 
 func TestNotSettable(t *testing.T) {
 	err := redact.Redact(1)
 	assert.Error(t, err)
+
+	// test does not apply for redact.AsCopy()
 }
 
 func TestInterface(t *testing.T) {
-	i := interface{}(&TestStruct{})
+	newInterface := func() interface{} {
+		return interface{}(&TestStruct{})
+	}
+
+	validate := func(i interface{}) {
+		assert.Equal(t, i, &TestStruct{Secret: redact.RedactStrConst, SecretStringType: redact.RedactStrConst})
+	}
+
+	i := newInterface()
 	err := redact.Redact(&i)
 	assert.NoError(t, err)
-	assert.Equal(t, i, &TestStruct{Secret: redact.RedactStrConst, SecretStringType: redact.RedactStrConst})
+	validate(i)
+
+	i = newInterface()
+	iCopy := redact.AsCopy(i)
+	assert.Equal(t, newInterface(), i)
+	validate(iCopy)
+	redact.ValidateNoExportedAliases(i, iCopy)
+}
+
+func TestNestedInterface(t *testing.T) {
+	newTestStruct := func() *TestStruct {
+		return &TestStruct{
+			Interface: &TestStruct{},
+		}
+	}
+
+	validate := func(tStruct *TestStruct) {
+		assert.Equal(t, tStruct, &TestStruct{
+			Secret:           redact.RedactStrConst,
+			SecretStringType: redact.RedactStrConst,
+			Interface: &TestStruct{
+				Secret:           redact.RedactStrConst,
+				SecretStringType: redact.RedactStrConst,
+			},
+		})
+	}
+
+	tStruct := newTestStruct()
+	err := redact.Redact(&tStruct)
+	assert.NoError(t, err)
+	validate(tStruct)
+
+	tStruct = newTestStruct()
+	tStructCopy := redact.AsCopy(tStruct)
+	assert.Equal(t, newTestStruct(), tStruct)
+	validate(tStructCopy)
+	redact.ValidateNoExportedAliases(tStruct, tStructCopy)
 }
 
 func TestNestedStructs(t *testing.T) {
-	tns := &TestNestedStruct{
-		TestStructPtr: &TestStruct{SecretPtr: &[]string{""}[0]},
+	newTestNestedStruct := func() *TestNestedStruct {
+		return &TestNestedStruct{
+			TestStructPtr: &TestStruct{SecretPtr: &[]string{""}[0]},
+		}
 	}
+
+	validate := func(tns *TestNestedStruct) {
+		assert.Equal(t, tns, &TestNestedStruct{
+			TestStruct:    TestStruct{Secret: redact.RedactStrConst, SecretStringType: redact.RedactStrConst, SecretPtr: nil},
+			TestStructPtr: &TestStruct{Secret: redact.RedactStrConst, SecretStringType: redact.RedactStrConst, SecretPtr: &[]string{redact.RedactStrConst}[0]},
+		})
+	}
+
+	tns := newTestNestedStruct()
 	err := redact.Redact(tns)
 	assert.NoError(t, err)
-	assert.Equal(t, tns, &TestNestedStruct{
-		TestStruct:    TestStruct{Secret: redact.RedactStrConst, SecretStringType: redact.RedactStrConst, SecretPtr: nil},
-		TestStructPtr: &TestStruct{Secret: redact.RedactStrConst, SecretStringType: redact.RedactStrConst, SecretPtr: &[]string{redact.RedactStrConst}[0]},
-	})
+	validate(tns)
+
+	tns = newTestNestedStruct()
+	tnsCopy := redact.AsCopy(tns)
+	assert.Equal(t, newTestNestedStruct(), tns)
+	validate(tnsCopy)
+	redact.ValidateNoExportedAliases(tns, tnsCopy)
 }
 
 func TestCustomRedactor(t *testing.T) {
-	redact.AddRedactor("lower", strings.ToLower)
-	s := &struct {
+	type SStruct struct {
 		S string `redact:"lower"`
-	}{"DATA"}
+	}
+
+	newSStruct := func() *SStruct {
+		return &SStruct{"DATA"}
+	}
+
+	validate := func(s *SStruct) {
+		assert.Equal(t, s.S, "data")
+	}
+
+	s := newSStruct()
+	redact.AddRedactor("lower", strings.ToLower)
 	err := redact.Redact(s)
 	assert.NoError(t, err)
-	assert.Equal(t, s.S, "data")
+	validate(s)
+
+	s = newSStruct()
+	sCopy := redact.AsCopy(s)
+	assert.Equal(t, newSStruct(), s)
+	validate(sCopy)
+	redact.ValidateNoExportedAliases(s, sCopy)
 }
 
 func TestArray(t *testing.T) {
-	tStruct := &struct {
+	type AStruct struct {
 		SecretStrings    [2]string
 		NotSecretStrings [2]string `redact:"nonsecret"`
-	}{}
+	}
 
+	newAStruct := func() *AStruct {
+		return &AStruct{}
+	}
+
+	validate := func(tStruct *AStruct) {
+		assert.Equal(t, "", tStruct.NotSecretStrings[0], "should contain non secret value")
+		assert.Equal(t, "", tStruct.NotSecretStrings[1], "should contain non secret value")
+		assert.Equal(t, redact.RedactStrConst, tStruct.SecretStrings[0], "should redact secret value")
+		assert.Equal(t, redact.RedactStrConst, tStruct.SecretStrings[1], "should redact secret value")
+
+	}
+
+	tStruct := newAStruct()
 	err := redact.Redact(tStruct)
 	assert.NoError(t, err, "should not fail to redact struct")
+	validate(tStruct)
 
-	assert.Equal(t, "", tStruct.NotSecretStrings[0], "should contain non secret value")
-	assert.Equal(t, "", tStruct.NotSecretStrings[1], "should contain non secret value")
-	assert.Equal(t, redact.RedactStrConst, tStruct.SecretStrings[0], "should redact secret value")
-	assert.Equal(t, redact.RedactStrConst, tStruct.SecretStrings[1], "should redact secret value")
+	tStruct = newAStruct()
+	tStructCopy := redact.AsCopy(tStruct)
+	assert.Equal(t, newAStruct(), tStruct)
+	validate(tStructCopy)
+	redact.ValidateNoExportedAliases(tStruct, tStructCopy)
 }


### PR DESCRIPTION
Implement redact.AsCopy().

Let's take a look and decide whether we want this or not?

OTOH, the implementation looks decently clean and probably reasonably trustworthy.

OTOH, I don't know that it has a strong probability of actually being faster than the existing optimized json library marshal/unmarshal + redact.Redact().  It also has the potential sharp edge that it can't guarantee that there are no aliases between input and output.

As a separate issue, the unit testing on Azure/redact isn't great and could probably do with some rework, but that's another story.